### PR TITLE
fix: remove deprecated mongo options

### DIFF
--- a/infra/config.js
+++ b/infra/config.js
@@ -62,10 +62,7 @@ base.postgres = {
 
 base.mongo = {
     uri: process.env.MONGO_URI || `mongodb://${APPLICATION_DOMAIN}/${name}`,
-    options: {
-        reconnectTries: process.env.MONGO_RECONNECT_TRIES || Number.MAX_VALUE,
-        reconnectInterval: process.env.MONGO_RECONNECT_INTERVAL || 30 * 1000,
-    },
+    options: {},
 };
 
 if (process.env.MTLS_CERT_PATH) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codefresh-io/service-base",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "main": "index.js",
   "description": "",
   "bin": {


### PR DESCRIPTION
This removes deprecated mongo connection options
`reconnectTries` and `reconnectInterval` as `useUnifiedTopology` is true from v4 of mongo driver.