### PR TITLE
fix(mongodb): fix TLS options

### DIFF
--- a/infra/config.js
+++ b/infra/config.js
@@ -66,9 +66,8 @@ base.mongo = {
 };
 
 if (process.env.MTLS_CERT_PATH) {
-    const credentials = fs.readFileSync(process.env.MTLS_CERT_PATH);
-    base.mongo.options.sslKey = credentials;
-    base.mongo.options.sslCert = credentials;
+    base.mongo.options.tls = true;
+    base.mongo.options.tlsCertificateKeyFile = process.env.MTLS_CERT_PATH;
 }
 
 base.logger = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codefresh-io/service-base",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "main": "index.js",
   "description": "",
   "bin": {


### PR DESCRIPTION
When `useNewUrlParser: true`, which is default since v4+ of `mongodb` driver, previous approach with passing TLS Cert content will not work, throwing `ENAMETOOLONG` error. We must pass path to the cert instead.