### PR TITLE
fix(mongodb): respect `MONGO_MTLS_VALIDATE` variable

### DIFF
--- a/infra/config.js
+++ b/infra/config.js
@@ -62,12 +62,14 @@ base.postgres = {
 
 base.mongo = {
     uri: process.env.MONGO_URI || `mongodb://${APPLICATION_DOMAIN}/${name}`,
+    /** @type {import('mongodb').MongoClientOptions} */
     options: {},
 };
 
 if (process.env.MTLS_CERT_PATH) {
     base.mongo.options.tls = true;
     base.mongo.options.tlsCertificateKeyFile = process.env.MTLS_CERT_PATH;
+    base.mongo.options.tlsInsecure = process.env.MONGO_MTLS_VALIDATE === 'false';
 }
 
 base.logger = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codefresh-io/service-base",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "main": "index.js",
   "description": "",
   "bin": {


### PR DESCRIPTION
This allows bypassing TLS validation if `MONGO_MTLS_VALIDATE` env variable is set to `"false"`.